### PR TITLE
fix construction of ExceptionlessClient

### DIFF
--- a/src/ExceptionlessClient-spec.ts
+++ b/src/ExceptionlessClient-spec.ts
@@ -54,4 +54,21 @@ describe('ExceptionlessClient', () => {
     expect(builder.target.message).to.equal('Unit Test message');
     expect(builder.target.data).to.be.undefined;
   });
+
+  it('should allow construction via apiKey and serverUrl parameters', () => {
+    let client = new ExceptionlessClient('LhhP1C9gijpSKCslHHCvwdSIz298twx271n1l6xw', 'http://localhost:50000');
+
+    expect(client.config.apiKey).to.equal('LhhP1C9gijpSKCslHHCvwdSIz298twx271n1l6xw');
+    expect(client.config.serverUrl).to.equal('http://localhost:50000');
+  });
+
+  it('should allow construction via a configuration object', () => {
+    let client = new ExceptionlessClient({
+      apiKey: 'LhhP1C9gijpSKCslHHCvwdSIz298twx271n1l6xw',
+      serverUrl: 'http://localhost:50000'
+    });
+
+    expect(client.config.apiKey).to.equal('LhhP1C9gijpSKCslHHCvwdSIz298twx271n1l6xw');
+    expect(client.config.serverUrl).to.equal('http://localhost:50000');
+  });
 });

--- a/src/ExceptionlessClient.ts
+++ b/src/ExceptionlessClient.ts
@@ -22,7 +22,7 @@ export class ExceptionlessClient {
   constructor(settings: IConfigurationSettings);
   constructor(apiKey: string, serverUrl?: string);
   constructor(settingsOrApiKey?: IConfigurationSettings | string, serverUrl?: string) {
-    if (typeof settingsOrApiKey !== 'object') {
+    if (typeof settingsOrApiKey === 'object') {
       this.config = new Configuration(settingsOrApiKey);
     } else {
       this.config = new Configuration({ apiKey: <string>settingsOrApiKey, serverUrl: serverUrl });


### PR DESCRIPTION
According to the readme, you should be able to instantiate an ExceptionlessClient like so:

```
var client = new exceptionless.ExceptionlessClient('API_KEY_HERE');
// or with an api key and server url
var client = new exceptionless.ExceptionlessClient('API_KEY_HERE', 'http://localhost:50000');
// or with a configuration object
var client = new exceptionless.ExceptionlessClient({
  apiKey: 'API_KEY_HERE',
  serverUrl: 'http://localhost:50000',
  submissionBatchSize: 100
});
```

As far as I can tell, these constructor arguments don't actually work as-is, due to a flipped equality comparison in the constructor.
