### PR TITLE
Update 'Content-Length' value for fix characters missing

### DIFF
--- a/src/submission/NodeSubmissionAdapter.ts
+++ b/src/submission/NodeSubmissionAdapter.ts
@@ -30,7 +30,7 @@ export class NodeSubmissionAdapter implements ISubmissionAdapter {
     if (request.method === 'POST') {
       options.headers = {
         'Content-Type': 'application/json',
-        'Content-Length': request.data.length
+        'Content-Length': new Buffer(request.data).length
       };
     }
 


### PR DESCRIPTION
In other languages (Chinese , Japanese .... )
One word maybe use two or three bytes ...

```javascript
var a = "我爱你";
console.log(a.length); //3
console.log(new Buffer(a).length); //9
```
So you should use new Buffer for set "Content-Length" and this problem will be resolve