### PR TITLE
Fixes #85 Improvements to session management (Breaking Change) 

### DIFF
--- a/example/browser/index.js
+++ b/example/browser/index.js
@@ -13,6 +13,7 @@ await Exceptionless.startup((c) => {
   c.updateSettingsWhenIdleInterval = 15000;
   c.usePersistedQueueStorage = true;
   c.setUserIdentity("12345678", "Blake");
+  c.useSessions();
 
   // set some default data
   c.defaultData["SampleUser"] = {

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -33,8 +33,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2015 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2015 --format=esm --outfile=dist/index.bundle.min.js",
-    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2015 --format=esm --watch --outfile=dist/index.bundle.js"
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.min.js",
+    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --watch --outfile=dist/index.bundle.js"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,7 +45,7 @@
     "testEnvironment": "jsdom"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=dist/index.bundle.min.js",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.min.js",
     "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --watch --outfile=dist/index.bundle.js",
     "test": "jest"
   },

--- a/packages/browser/src/plugins/BrowserLifeCyclePlugin.ts
+++ b/packages/browser/src/plugins/BrowserLifeCyclePlugin.ts
@@ -17,12 +17,19 @@ export class BrowserLifeCyclePlugin implements IEventPlugin {
 
     this._client = context.client;
 
-    globalThis.addEventListener("beforeunload", () => void this._client?.suspend());
+    globalThis.addEventListener("beforeunload", () => {
+      if (this._client?.config.sessionsEnabled) {
+        void this._client?.submitSessionEnd();
+      }
+
+      void this._client?.suspend();
+    });
+
     document.addEventListener("visibilitychange", () => {
       if (document.visibilityState === 'visible') {
-        void this._client?.startup()
+        void this._client?.startup();
       } else {
-        void this._client?.suspend()
+        void this._client?.suspend();
       }
     });
 

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "lib": [
       "DOM",
-      "ES2020"
+      "ES2021"
     ],
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,7 +45,7 @@
     "testEnvironment": "jsdom"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=dist/index.bundle.min.js",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.min.js",
     "watch": "tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --watch --outfile=dist/index.bundle.js",
     "test": "jest"
   },

--- a/packages/core/src/EventBuilder.ts
+++ b/packages/core/src/EventBuilder.ts
@@ -1,5 +1,5 @@
 import { ExceptionlessClient } from "./ExceptionlessClient.js";
-import { Event, KnownEventDataKeys } from "./models/Event.js";
+import { Event, EventType, KnownEventDataKeys } from "./models/Event.js";
 import { ManualStackingInfo } from "./models/data/ManualStackingInfo.js";
 import { UserInfo } from "./models/data/UserInfo.js";
 import { EventContext } from "./models/EventContext.js";
@@ -19,7 +19,7 @@ export class EventBuilder {
     this.context = context || new EventContext();
   }
 
-  public setType(type: string): EventBuilder {
+  public setType(type: EventType): EventBuilder {
     if (type) {
       this.target.type = type;
     }

--- a/packages/core/src/ExceptionlessClient.ts
+++ b/packages/core/src/ExceptionlessClient.ts
@@ -46,6 +46,10 @@ export class ExceptionlessClient {
       // TODO: Can we schedule this as part of startup?
       await queue.process();
     }
+
+    if (this.config.sessionsEnabled) {
+      await this.submitSessionStart();
+    }
   }
 
   /** Submit events, pause any timers and go into low power mode. */
@@ -175,27 +179,21 @@ export class ExceptionlessClient {
     return this.createSessionStart().submit();
   }
 
-  public async submitSessionEnd(sessionIdOrUserId: string): Promise<void> {
-    if (sessionIdOrUserId && this.config.enabled && this.config.isValid) {
-      this.config.services.log.info(
-        `Submitting session end: ${sessionIdOrUserId}`,
-      );
-      await this.config.services.submissionClient.submitHeartbeat(
-        sessionIdOrUserId,
-        true,
-      );
+  public async submitSessionEnd(sessionIdOrUserId?: string): Promise<void> {
+    const { currentSessionIdentifier, enabled, isValid, services } = this.config;
+    const sessionId = sessionIdOrUserId || currentSessionIdentifier;
+    if (sessionId && enabled && isValid) {
+      services.log.info(`Submitting session end: ${sessionId}`);
+      await services.submissionClient.submitHeartbeat(sessionId, true);
     }
   }
 
-  public async submitSessionHeartbeat(sessionIdOrUserId: string): Promise<void> {
-    if (sessionIdOrUserId && this.config.enabled && this.config.isValid) {
-      this.config.services.log.info(
-        `Submitting session heartbeat: ${sessionIdOrUserId}`,
-      );
-      await this.config.services.submissionClient.submitHeartbeat(
-        sessionIdOrUserId,
-        false,
-      );
+  public async submitSessionHeartbeat(sessionIdOrUserId?: string): Promise<void> {
+    const { currentSessionIdentifier, enabled, isValid, services } = this.config;
+    const sessionId = sessionIdOrUserId || currentSessionIdentifier;
+    if (sessionId && enabled && isValid) {
+      services.log.info(`Submitting session heartbeat: ${sessionId}`);
+      await services.submissionClient.submitHeartbeat(sessionId, false);
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,7 @@ export { DuplicateCheckerPlugin } from "./plugins/default/DuplicateCheckerPlugin
 export { EventExclusionPlugin } from "./plugins/default/EventExclusionPlugin.js";
 export { HeartbeatPlugin } from "./plugins/default/HeartbeatPlugin.js";
 export { ReferenceIdPlugin } from "./plugins/default/ReferenceIdPlugin.js";
+export { SessionIdManagementPlugin } from "./plugins/default/SessionIdManagementPlugin.js";
 export { IgnoredErrorProperties, SimpleErrorPlugin } from "./plugins/default/SimpleErrorPlugin.js"
 export { SubmissionMethodPlugin } from "./plugins/default/SubmissionMethodPlugin.js";
 export { EventContext } from "./models/EventContext.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@ export type { ILog } from "./logging/ILog.js";
 export { ConsoleLog } from "./logging/ConsoleLog.js";
 export { NullLog } from "./logging/NullLog.js";
 
-export type { Event, IEventData } from "./models/Event.js";
+export type { Event, EventType, IEventData } from "./models/Event.js";
 export { KnownEventDataKeys } from "./models/Event.js";
 export type { EnvironmentInfo } from "./models/data/EnvironmentInfo.js";
 export type { ManualStackingInfo } from "./models/data/ManualStackingInfo.js";

--- a/packages/core/src/models/Event.ts
+++ b/packages/core/src/models/Event.ts
@@ -5,9 +5,11 @@ import { UserInfo } from "./data/UserInfo.js";
 import { UserDescription } from "./data/UserDescription.js";
 import { ManualStackingInfo } from "./data/ManualStackingInfo.js";
 
+export type EventType = "error" | "usage" | "log" | "404" | "session" | string;
+
 export interface Event {
   /** The event type (ie. error, log message, feature usage). */
-  type?: string;
+  type?: EventType;
   /** The event source (ie. machine name, log name, feature name). */
   source?: string;
   /** The date that the event occurred on. */

--- a/packages/core/src/plugins/default/ReferenceIdPlugin.ts
+++ b/packages/core/src/plugins/default/ReferenceIdPlugin.ts
@@ -9,7 +9,7 @@ export class ReferenceIdPlugin implements IEventPlugin {
   public run(context: EventPluginContext): Promise<void> {
     if (!context.event.reference_id && context.event.type === "error") {
       // PERF: Optimize identifier creation.
-      context.event.reference_id = guid().replace("-", "").substring(0, 10);
+      context.event.reference_id = guid().replaceAll("-", "").substring(0, 10);
     }
 
     return Promise.resolve();

--- a/packages/core/src/plugins/default/SessionIdManagementPlugin.ts
+++ b/packages/core/src/plugins/default/SessionIdManagementPlugin.ts
@@ -1,0 +1,29 @@
+import { guid } from "../../Utils.js";
+import { EventPluginContext } from "../EventPluginContext.js";
+import { IEventPlugin } from "../IEventPlugin.js";
+
+export class SessionIdManagementPlugin implements IEventPlugin {
+  public priority = 25;
+  public name = "SessionIdManagementPlugin";
+
+  public run(context: EventPluginContext): Promise<void> {
+    const ev = context.event;
+    const isSessionStart: boolean = ev.type === "session";
+    const { config } = context.client;
+    if (isSessionStart || !config.currentSessionIdentifier) {
+      config.currentSessionIdentifier = guid().replaceAll("-", "");
+    }
+
+    if (isSessionStart) {
+      ev.reference_id = config.currentSessionIdentifier;
+    } else {
+      if (!ev.data) {
+        ev.data = {};
+      }
+
+      ev.data["@ref:session"] = config.currentSessionIdentifier;
+    }
+
+    return Promise.resolve();
+  }
+}

--- a/packages/core/test/plugins/default/EventExclusionPlugin.test.ts
+++ b/packages/core/test/plugins/default/EventExclusionPlugin.test.ts
@@ -2,7 +2,7 @@ import { describe, test } from "@jest/globals";
 import { expect } from "expect";
 
 import { ExceptionlessClient } from "../../../src/ExceptionlessClient.js";
-import { Event, KnownEventDataKeys } from "../../../src/models/Event.js";
+import { Event, EventType, KnownEventDataKeys } from "../../../src/models/Event.js";
 import { InnerErrorInfo } from "../../../src/models/data/ErrorInfo.js";
 import { EventExclusionPlugin } from "../../../src/plugins/default/EventExclusionPlugin.js";
 import { EventPluginContext } from "../../../src/plugins/EventPluginContext.js";
@@ -142,7 +142,7 @@ describe("EventExclusionPlugin", () => {
   });
 
   describe("should exclude source type", () => {
-    const run = async (type: string | null | undefined, source: string | undefined, settingKey: string | null | undefined, settingValue: string | null | undefined): Promise<boolean> => {
+    const run = async (type: EventType | null | undefined, source: string | undefined, settingKey: string | null | undefined, settingValue: string | null | undefined): Promise<boolean> => {
       const client = new ExceptionlessClient();
 
       if (typeof settingKey === "string") {

--- a/packages/core/test/submission/TestSubmissionClient.test.ts
+++ b/packages/core/test/submission/TestSubmissionClient.test.ts
@@ -20,7 +20,7 @@ describe("TestSubmissionClient", () => {
     const apiFetchMock = jest.fn<(url: string, options: FetchOptions) => Promise<Response<undefined>>>()
       .mockReturnValueOnce(Promise.resolve(new Response(202, "", NaN, NaN, undefined)));
 
-    const events = [{ type: "log", message: "From js client", reference_id: "123454321" }];
+    const events: Event[] = [{ type: "log", message: "From js client", reference_id: "123454321" }];
     const client = new TestSubmissionClient(config, apiFetchMock);
     await client.submitEvents(events);
     expect(apiFetchMock).toHaveBeenCalledTimes(1);

--- a/packages/node/src/plugins/NodeLifeCyclePlugin.ts
+++ b/packages/node/src/plugins/NodeLifeCyclePlugin.ts
@@ -23,6 +23,10 @@ export class NodeLifeCyclePlugin implements IEventPlugin {
         void this._client?.submitLog("beforeExit", message, "Error");
       }
 
+      if (this._client?.config.sessionsEnabled) {
+        void this._client?.submitSessionEnd();
+      }
+
       void this._client?.suspend();
       // Application will now exit.
     });

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,7 +33,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=dist/index.bundle.min.js",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.min.js",
     "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --watch --outfile=dist/index.bundle.js"
   },
   "sideEffects": false,

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": [
+      "DOM",
+      "ES2021"
+    ],
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -33,7 +33,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2019 --format=esm --outfile=dist/index.bundle.min.js",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2017 --format=esm --outfile=dist/index.bundle.min.js",
     "watch": "tsc -p tsconfig.json -w --preserveWatchOutput & && esbuild src/index.ts --bundle --sourcemap --target=es2017 --format=esm --watch --outfile=dist/index.bundle.js &"
   },
   "sideEffects": false,

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2020"],
+    "lib": [
+      "DOM",
+      "ES2021"
+    ],
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "lib": [
-      "ES2020",
+      "ES2021",
       "DOM"
     ],
     "module": "ESNext",


### PR DESCRIPTION
This sync's changes over from https://github.com/exceptionless/Exceptionless.Net and ensures that you opt into heartbeats.

The breaking change is around heartbeats not being sent / configured when you call setUserIdentity.

I also synced the compiler options which we might want to up our bundle to ES2019 or ES2021 from ES2017. I noticed node is still targeting node 12 with CJS which the new default is ESM. I think we may want to bump this and break this too while we are at it.