### PR TITLE
Added support for headers

### DIFF
--- a/packages/browser/src/plugins/BrowserRequestInfoPlugin.ts
+++ b/packages/browser/src/plugins/BrowserRequestInfoPlugin.ts
@@ -42,8 +42,7 @@ export class BrowserRequestInfoPlugin implements IEventPlugin {
       port: location.port && location.port !== ""
         ? parseInt(location.port, 10)
         : 80,
-      path: location.pathname,
-      // client_ip_address: "TODO"
+      path: location.pathname
     };
 
     if (config.includeCookies) {
@@ -53,7 +52,7 @@ export class BrowserRequestInfoPlugin implements IEventPlugin {
     if (config.includeQueryString) {
       requestInfo.query_string = parseQueryString(
         location.search.substring(1),
-        exclusions,
+        exclusions
       );
     }
 

--- a/packages/core/src/configuration/Configuration.ts
+++ b/packages/core/src/configuration/Configuration.ts
@@ -102,6 +102,7 @@ export class Configuration {
   private _includeUserName = true;
   private _includeMachineName = true;
   private _includeIpAddress = true;
+  private _includeHeaders = true;
   private _includeCookies = true;
   private _includePostData = true;
   private _includeQueryString = true;
@@ -212,6 +213,7 @@ export class Configuration {
     this._includeUserName = val;
     this._includeMachineName = val;
     this._includeIpAddress = val;
+    this._includeHeaders = val;
     this._includeCookies = val;
     this._includePostData = val;
     this._includeQueryString = val;
@@ -257,6 +259,22 @@ export class Configuration {
    */
   public set includeIpAddress(value: boolean) {
     this._includeIpAddress = value === true;
+  }
+
+  /**
+   * Gets a value indicating whether to include Headers.
+   * NOTE: DataExclusions are applied to all Header keys when enabled.
+   */
+  public get includeHeaders(): boolean {
+    return this._includeHeaders;
+  }
+
+  /**
+   * Sets a value indicating whether to include Headers.
+   * NOTE: DataExclusions are applied to all Headers keys when enabled.
+   */
+  public set includeHeaders(value: boolean) {
+    this._includeHeaders = value === true;
   }
 
   /**

--- a/packages/core/src/models/data/RequestInfo.ts
+++ b/packages/core/src/models/data/RequestInfo.ts
@@ -7,6 +7,7 @@ export interface RequestInfo {
   path?: string;
   referrer?: string;
   client_ip_address?: string;
+  headers?: Record<string, string[]>;
   cookies?: Record<string, string>;
   post_data?: Record<string, unknown>;
   query_string?: Record<string, string>;

--- a/packages/node/src/plugins/NodeRequestInfoPlugin.ts
+++ b/packages/node/src/plugins/NodeRequestInfoPlugin.ts
@@ -74,6 +74,30 @@ export class NodeRequestInfoPlugin implements IEventPlugin {
       requestInfo.cookies = getCookies(request.headers.cookie, exclusions) as Record<string, string>;
     }
 
+    if (config.includeHeaders) {
+      const ignoredHeaders = [
+        "Authorization",
+        "Cookie",
+        "Host",
+        "Method",
+        "Path",
+        "Proxy-Authorization",
+        "Referer",
+        "User-Agent"
+      ];
+
+      const json = stringify(request.headers, [...ignoredHeaders, ...exclusions]);
+      if (!isEmpty(json)) {
+        const headers: Record<string, string[]> = {};
+        const parsedHeaders = JSON.parse(json) as Record<string, string>;
+        for (const key in parsedHeaders) {
+          headers[key] = parsedHeaders[key].split(/,(?=(?:(?:[^"]*"){2})*[^"]*$)/).map(value => value.trim());
+        }
+
+        requestInfo.headers = headers;
+      }
+    }
+
     if (config.includeQueryString) {
       const json = stringify(request.params, exclusions);
       if (!isEmpty(json)) {


### PR DESCRIPTION
I'm not sure about any differences between node headers vs express headers https://nodejs.org/api/http.html#requestgetheaders

All of our request info collector works off of request (express?) object, seems to just have string values but the node docs has both..