### PR TITLE
Target ES2022

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    ecmaVersion: 2020,
+    ecmaVersion: 2022,
     sourceType: "module",
     project: ["./tsconfig.json"],
     tsconfigRootDir: __dirname

--- a/packages/angularjs/package.json
+++ b/packages/angularjs/package.json
@@ -33,8 +33,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.min.js",
-    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --watch --outfile=dist/index.bundle.js"
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.min.js",
+    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --watch --outfile=dist/index.bundle.js"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -45,8 +45,8 @@
     "testEnvironment": "jsdom"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.min.js",
-    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --watch --outfile=dist/index.bundle.js",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.min.js",
+    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --watch --outfile=dist/index.bundle.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/browser/test/plugins/BrowserErrorPlugin.test.ts
+++ b/packages/browser/test/plugins/BrowserErrorPlugin.test.ts
@@ -53,6 +53,16 @@ describe("BrowserErrorPlugin", () => {
       });
     });
 
+    test("should add error cause", async () => {
+      const error = {
+        someProperty: "Test"
+      };
+      await processError(new Error("Error With Cause", { cause: error }));
+      const additionalData = getAdditionalData(context.event);
+      expect(additionalData).not.toBeNull();
+      expect(additionalData?.cause).toStrictEqual(error);
+    });
+
     test("should add custom properties to additional data", async () => {
       const error = {
         someProperty: "Test"

--- a/packages/browser/tsconfig.json
+++ b/packages/browser/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "outDir": "dist",
     "rootDir": "src",
     "types": ["jest"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,8 +45,8 @@
     "testEnvironment": "jsdom"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.min.js",
-    "watch": "tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --watch --outfile=dist/index.bundle.js",
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.min.js",
+    "watch": "tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --watch --outfile=dist/index.bundle.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/packages/node/tsconfig.json
+++ b/packages/node/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2021"],
+    "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",
     "types": ["node", "jest"]

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,8 +33,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.min.js",
-    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --watch --outfile=dist/index.bundle.js"
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.min.js",
+    "watch": "tsc -p ../core/tsconfig.json -w --preserveWatchOutput & tsc -p tsconfig.json -w --preserveWatchOutput & esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --watch --outfile=dist/index.bundle.js"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "outDir": "dist",
     "rootDir": "src",
     "jsx": "react"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -33,8 +33,8 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2021 --format=esm --outfile=dist/index.bundle.min.js",
-    "watch": "tsc -p tsconfig.json -w --preserveWatchOutput & && esbuild src/index.ts --bundle --sourcemap --target=es2021 --format=esm --watch --outfile=dist/index.bundle.js &"
+    "build": "tsc -p tsconfig.json && esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.js && esbuild src/index.ts --bundle --minify --sourcemap --target=es2022 --format=esm --outfile=dist/index.bundle.min.js",
+    "watch": "tsc -p tsconfig.json -w --preserveWatchOutput & && esbuild src/index.ts --bundle --sourcemap --target=es2022 --format=esm --watch --outfile=dist/index.bundle.js &"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2022"],
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
-    "lib": ["ES2021", "DOM"],
+    "lib": ["DOM", "ES2022"],
     "module": "ESNext",
     "moduleResolution": "Node",
     "noImplicitAny": true,
@@ -18,7 +18,7 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2021",
+    "target": "ES2022",
     "useUnknownInCatchVariables": true
   }
 }


### PR DESCRIPTION
main reason is browsers should be updating and supported features. But also makes our bundles slightly smaller and biggest of all gives us updated definitions for things like Error Cause/extra error constructors....

NOTE: This would force at least a minor bump or major bump.

https://caniuse.com/?search=es2022
https://caniuse.com/mdn-javascript_builtins_error_cause